### PR TITLE
Task/25 add Leaderboard API, add Loader component, linter fixes

### DIFF
--- a/packages/client/.stylelintrc.json
+++ b/packages/client/.stylelintrc.json
@@ -3,6 +3,7 @@
     "stylelint-config-standard"
   ],
   "rules": {
-    "selector-class-pattern": null
+    "selector-class-pattern": null,
+    "selector-pseudo-element-colon-notation": null
   }
 }

--- a/packages/client/.stylelintrc.json
+++ b/packages/client/.stylelintrc.json
@@ -3,7 +3,6 @@
     "stylelint-config-standard"
   ],
   "rules": {
-    "selector-class-pattern": null,
-    "selector-pseudo-element-colon-notation": null
+    "selector-class-pattern": null
   }
 }

--- a/packages/client/.stylelintrc.json
+++ b/packages/client/.stylelintrc.json
@@ -1,9 +1,9 @@
 {
   "extends": [
-    "stylelint-config-standard",
-    "stylelint-config-recess-order"
+    "stylelint-config-standard"
   ],
   "rules": {
-    "selector-class-pattern": null
+    "selector-class-pattern": null,
+    "selector-pseudo-element-colon-notation": null
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint:scripts": "eslint . --fix",
-    "lint:styles": "stylelint 'src/**/*.css' --fix",
+    "lint:styles": "stylelint src/**/*.css --fix",
     "lint": "npm-run-all -c -p lint:scripts lint:styles",
     "format": "prettier --write .",
     "test": "jest ./"

--- a/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
+++ b/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
@@ -1,14 +1,11 @@
+import { BASE_URL_YANDEX, LEADERBOARD } from '../../utils/apiConstans';
 import { TLeaderboard, TLider } from './typings';
 
 class LeaderboardAPI {
-  constructor(baseUrl: string) {
-    this._baseUrl = baseUrl;
-  }
-
-  private _baseUrl: string;
+  constructor(private _baseUrl: string) {}
 
   async getAllLiders(data: TLeaderboard) {
-    const response = await fetch(`${this._baseUrl}/all`, {
+    const response: Response = await fetch(`${this._baseUrl}/all`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -26,7 +23,7 @@ class LeaderboardAPI {
   }
 
   async addLider(data: TLider) {
-    const response = await fetch(`${this._baseUrl}`, {
+    const response: Response = await fetch(`${this._baseUrl}`, {
       method: 'POST',
       credentials: 'include',
       headers: {
@@ -41,4 +38,4 @@ class LeaderboardAPI {
   }
 }
 
-export const leaderboardAPI = new LeaderboardAPI('https://ya-praktikum.tech/api/v2/leaderboard');
+export const leaderboardAPI = new LeaderboardAPI(`${BASE_URL_YANDEX}${LEADERBOARD}`);

--- a/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
+++ b/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
@@ -1,0 +1,44 @@
+import { TLeaderboard, TLider } from './typings';
+
+class LeaderboardAPI {
+  constructor(baseUrl: string) {
+    this._baseUrl = baseUrl;
+  }
+
+  private _baseUrl: string;
+
+  async getAllLiders(data: TLeaderboard) {
+    const response = await fetch(`${this._baseUrl}/all`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (response.ok) {
+      const result = await response.json();
+      return result;
+    }
+
+    return Promise.reject(response.status);
+  }
+
+  async addLider(data: TLider) {
+    const response = await fetch(`${this._baseUrl}`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (response.ok) return response;
+
+    return Promise.reject(response.status);
+  }
+}
+
+export const leaderboardAPI = new LeaderboardAPI('https://ya-praktikum.tech/api/v2/leaderboard');

--- a/packages/client/src/api/LeaderboardAPI/typings.ts
+++ b/packages/client/src/api/LeaderboardAPI/typings.ts
@@ -3,7 +3,6 @@ export type TLider = {
     id: number;
     name: string;
     score: number;
-    place?: number;
     avatar?: string;
   };
   ratingFieldName: string;

--- a/packages/client/src/api/LeaderboardAPI/typings.ts
+++ b/packages/client/src/api/LeaderboardAPI/typings.ts
@@ -1,0 +1,17 @@
+export type TLider = {
+  data: {
+    id: number;
+    name: string;
+    score: number;
+    place?: number;
+    avatar?: string;
+  };
+  ratingFieldName: string;
+  teamName: string;
+};
+
+export type TLeaderboard = {
+  ratingFieldName: string,
+  cursor: number,
+  limit: number
+};

--- a/packages/client/src/components/App/typings.ts
+++ b/packages/client/src/components/App/typings.ts
@@ -1,3 +1,3 @@
 export type StringObject = {
-  [key:string]: string
+  [key: string]: string
 };

--- a/packages/client/src/components/Leaderboard/TableHead/TableHead.tsx
+++ b/packages/client/src/components/Leaderboard/TableHead/TableHead.tsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { Sorting, SortEventProps, Order, TLeaderBoard } from '../../../pages/leaderboard/typings';
 import styles from './TableHead.module.css';
 
-export function TableHead({ sorting } : SortEventProps) {
+export function TableHead({ sorting }: SortEventProps) {
   const [selectedSort, setSelectedSort] = useState<Sorting>({
-    sort: 'points',
+    sort: 'score',
     order: Order.DESC,
   });
 
@@ -21,8 +21,8 @@ export function TableHead({ sorting } : SortEventProps) {
     ? selectedSort.order
     : Order.DESC;
 
-  const pointsSort: keyof TLeaderBoard = 'points';
-  const pointsOrder: Order = selectedSort.sort === pointsSort
+  const scoreSort: keyof TLeaderBoard = 'score';
+  const scoreOrder: Order = selectedSort.sort === scoreSort
     ? selectedSort.order
     : Order.ASC;
 
@@ -39,19 +39,19 @@ export function TableHead({ sorting } : SortEventProps) {
             data-sort={nameSort}
             data-order={nameOrder}
           >
-            Name
+            Имя
           </button>
         </th>
         <th className={`${styles.th} ${styles.points}`}>
           <button
             className={styles.button}
             type="button"
-            onClick={() => changeSort(pointsSort, pointsOrder)}
-            data-active={selectedSort.sort === pointsSort ? 'true' : 'false'}
-            data-sort={pointsSort}
-            data-order={pointsOrder}
+            onClick={() => changeSort(scoreSort, scoreOrder)}
+            data-active={selectedSort.sort === scoreSort ? 'true' : 'false'}
+            data-sort={scoreSort}
+            data-order={scoreOrder}
           >
-            Points
+            Очки
           </button>
         </th>
       </tr>

--- a/packages/client/src/components/Leaderboard/TableRow/TableRow.tsx
+++ b/packages/client/src/components/Leaderboard/TableRow/TableRow.tsx
@@ -27,7 +27,7 @@ export function TableRow({ row }: Record<string, TLeaderBoardProps>) {
         </div>
       </td>
       <td className={styles.td}>
-        <span className={styles.points}>{data.points}</span>
+        <span className={styles.points}>{data.score}</span>
       </td>
     </tr>
   );

--- a/packages/client/src/components/LinkRow/LinkRow.tsx
+++ b/packages/client/src/components/LinkRow/LinkRow.tsx
@@ -3,7 +3,7 @@ import { TLinkRowProps } from './typings';
 
 export function LinkRow({ rowData, path }: TLinkRowProps) {
   const navigate = useNavigate();
-  const handleRowClick = ():void => {
+  const handleRowClick = (): void => {
     navigate(`./${path}`);
   };
 

--- a/packages/client/src/components/Loader/Loader.module.css
+++ b/packages/client/src/components/Loader/Loader.module.css
@@ -1,0 +1,112 @@
+.loader {
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .loader div {
+    transform-origin: 40px 40px;
+    animation: loader 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loader div {
+    display: none;
+  }
+
+  .loader::before {
+    content: "Loading...";
+  }
+}
+
+.loader div:after {
+  position: absolute;
+  display: block;
+  content: " ";
+  width: 7px;
+  height: 7px;
+  margin: -4px 0 0 -4px;
+  background: var(--accent-darken-color);
+  border-radius: 50%;
+}
+
+.loader div:nth-child(1):after {
+  top: 63px;
+  left: 63px;
+}
+
+.loader div:nth-child(2) {
+  animation-delay: -0.072s;
+}
+
+.loader div:nth-child(2):after {
+  top: 68px;
+  left: 56px;
+}
+
+.loader div:nth-child(3) {
+  animation-delay: -0.108s;
+}
+
+.loader div:nth-child(3):after {
+  top: 71px;
+  left: 48px;
+}
+
+.loader div:nth-child(4) {
+  animation-delay: -0.144s;
+}
+
+.loader div:nth-child(4):after {
+  top: 72px;
+  left: 40px;
+}
+
+.loader div:nth-child(5) {
+  animation-delay: -0.18s;
+}
+
+.loader div:nth-child(5):after {
+  top: 71px;
+  left: 32px;
+}
+
+.loader div:nth-child(6) {
+  animation-delay: -0.216s;
+}
+
+.loader div:nth-child(6):after {
+  top: 68px;
+  left: 24px;
+}
+
+.loader div:nth-child(7) {
+  animation-delay: -0.252s;
+}
+
+.loader div:nth-child(7):after {
+  top: 63px;
+  left: 17px;
+}
+
+.loader div:nth-child(8) {
+  animation-delay: -0.288s;
+}
+
+.loader div:nth-child(8):after {
+  top: 56px;
+  left: 12px;
+}
+
+@keyframes loader {
+  0% {
+    transform: rotate(0deg);
+  }
+  
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/client/src/components/Loader/Loader.module.css
+++ b/packages/client/src/components/Loader/Loader.module.css
@@ -22,7 +22,7 @@
   }
 }
 
-.loader div:after {
+.loader div::after {
   position: absolute;
   display: block;
   content: " ";
@@ -33,7 +33,7 @@
   border-radius: 50%;
 }
 
-.loader div:nth-child(1):after {
+.loader div:nth-child(1)::after {
   top: 63px;
   left: 63px;
 }
@@ -42,7 +42,7 @@
   animation-delay: -0.072s;
 }
 
-.loader div:nth-child(2):after {
+.loader div:nth-child(2)::after {
   top: 68px;
   left: 56px;
 }
@@ -51,7 +51,7 @@
   animation-delay: -0.108s;
 }
 
-.loader div:nth-child(3):after {
+.loader div:nth-child(3)::after {
   top: 71px;
   left: 48px;
 }
@@ -60,7 +60,7 @@
   animation-delay: -0.144s;
 }
 
-.loader div:nth-child(4):after {
+.loader div:nth-child(4)::after {
   top: 72px;
   left: 40px;
 }
@@ -69,7 +69,7 @@
   animation-delay: -0.18s;
 }
 
-.loader div:nth-child(5):after {
+.loader div:nth-child(5)::after {
   top: 71px;
   left: 32px;
 }
@@ -78,7 +78,7 @@
   animation-delay: -0.216s;
 }
 
-.loader div:nth-child(6):after {
+.loader div:nth-child(6)::after {
   top: 68px;
   left: 24px;
 }
@@ -87,7 +87,7 @@
   animation-delay: -0.252s;
 }
 
-.loader div:nth-child(7):after {
+.loader div:nth-child(7)::after {
   top: 63px;
   left: 17px;
 }
@@ -96,7 +96,7 @@
   animation-delay: -0.288s;
 }
 
-.loader div:nth-child(8):after {
+.loader div:nth-child(8)::after {
   top: 56px;
   left: 12px;
 }

--- a/packages/client/src/components/Loader/Loader.tsx
+++ b/packages/client/src/components/Loader/Loader.tsx
@@ -1,0 +1,16 @@
+import styles from './Loader.module.css';
+
+export function Loader() {
+  return (
+    <div className={styles.loader}>
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+      <div />
+    </div>
+  );
+}

--- a/packages/client/src/components/Loader/index.ts
+++ b/packages/client/src/components/Loader/index.ts
@@ -1,0 +1,1 @@
+export { Loader } from './Loader';

--- a/packages/client/src/hooks/useLeaders.ts
+++ b/packages/client/src/hooks/useLeaders.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { leaderboardAPI } from '../api/LeaderboardAPI/LeaderboardAPI';
+import { TLeaderBoard } from '../pages/leaderboard/typings';
+
+export function useLeaders(callback: (a: TLeaderBoard[]) => void): [() => void, boolean, string] {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchLeaders = () => {
+    leaderboardAPI.getAllLiders({
+      ratingFieldName: 'score',
+      cursor: 0,
+      limit: 15,
+    })
+      .then((result: Record<string, TLeaderBoard>[]) => {
+        const leaders = result.map((item: Record<string, TLeaderBoard>, index: number) => {
+          item.data.place = index + 1;
+          if (!item.data.name) {
+            item.data.name = 'No name';
+          }
+          return item.data;
+        });
+
+        callback(leaders);
+      })
+      .catch((e: Error) => {
+        setError(e.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return [fetchLeaders, loading, error];
+}

--- a/packages/client/src/pages/leaderboard/Leaderboard.module.css
+++ b/packages/client/src/pages/leaderboard/Leaderboard.module.css
@@ -12,8 +12,13 @@
 }
 
 .wrapper {
+	flex-grow: 1;
 	width: 900px;
+	display: flex;
 	max-width: 100%;
+	flex-direction: column;
+	align-items: center;
+	margin-top: 5%;
 }
 
 .table {
@@ -25,6 +30,7 @@
 .title {
 	font-size: 4em;
 	font-weight: 700;
+	margin-bottom: 0.8em;
 	color: var(--font-secondary-color);
 	text-align: center;
 }

--- a/packages/client/src/pages/leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/leaderboard/Leaderboard.tsx
@@ -70,16 +70,15 @@ export function Leaderboard() {
   ]);
   const [loading, setLoading] = useState(true);
 
-  async function fetchLeaders() {
+  function fetchLeaders() {
     const promise = leaderboardAPI.getAllLiders({
       ratingFieldName: 'score',
       cursor: 0,
       limit: 15,
     });
 
-    promise.then(
-      (result) => {
-        setLoading(false);
+    promise
+      .then((result) => {
         setLeaders(result.map((item: Record<string, TLeaderBoard>, index: number) => {
           item.data.place = index + 1;
           if (!item.data.name) {
@@ -87,11 +86,13 @@ export function Leaderboard() {
           }
           return item.data;
         }));
-      },
-      (error) => {
+      })
+      .catch((error) => {
         throw Error(`Something wrong with Leaderboard - ${error}`);
-      },
-    );
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }
 
   useEffect(() => {
@@ -119,8 +120,8 @@ export function Leaderboard() {
   const currentPlayerId = 3;
 
   return (
-    <div className={styles.leaderboard}>
-      <div className={styles.wrapper}>
+    <main className={styles.leaderboard}>
+      <section className={styles.wrapper}>
         <h1 className={styles.title}>Рейтинг игроков</h1>
 
         {loading
@@ -141,7 +142,7 @@ export function Leaderboard() {
             </table>
           )}
 
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }

--- a/packages/client/src/pages/leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/leaderboard/Leaderboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { leaderboardAPI } from '../../api/LeaderboardAPI/LeaderboardAPI';
 import { TableHead } from '../../components/Leaderboard/TableHead';
 import { TableRow } from '../../components/Leaderboard/TableRow';
@@ -7,77 +7,16 @@ import styles from './Leaderboard.module.css';
 import { Order, TLeaderBoard } from './typings';
 
 export function Leaderboard() {
-  const [leaders, setLeaders] = useState<TLeaderBoard[]>([
-    {
-      id: 123,
-      name: 'Безумный Майк',
-      score: 999999,
-      place: 1,
-    },
-    {
-      id: 1234,
-      name: 'Вася Петров',
-      score: 44234,
-      place: 2,
-    },
-    {
-      id: 12345,
-      name: 'Аня Иванов',
-      score: 23322,
-      place: 3,
-    },
-    {
-      id: 123456,
-      name: 'Владимир Ильич',
-      score: 20000,
-      place: 4,
-    },
-    {
-      id: 3213,
-      name: 'Кот',
-      avatar: '/avatar.jpg',
-      score: 12,
-      place: 5,
-    },
-    {
-      id: 12123,
-      name: 'Кот',
-      avatar: '/avatar.jpg',
-      score: 12,
-      place: 6,
-    },
-    {
-      id: 32,
-      name: 'Кот',
-      avatar: '/avatar.jpg',
-      score: 12,
-      place: 7,
-    },
-    {
-      id: 1233,
-      name: 'Кот',
-      avatar: '/avatar.jpg',
-      score: 12,
-      place: 8,
-    },
-    {
-      id: 33,
-      name: 'Кот',
-      avatar: '/avatar.jpg',
-      score: 12,
-      place: 9,
-    },
-  ]);
+  const [leaders, setLeaders] = useState<TLeaderBoard[]>([]);
   const [loading, setLoading] = useState(true);
 
   function fetchLeaders() {
-    const promise = leaderboardAPI.getAllLiders({
+    leaderboardAPI.getAllLiders({
       ratingFieldName: 'score',
       cursor: 0,
       limit: 15,
-    });
+    })
 
-    promise
       .then((result) => {
         setLeaders(result.map((item: Record<string, TLeaderBoard>, index: number) => {
           item.data.place = index + 1;

--- a/packages/client/src/pages/leaderboard/typings.ts
+++ b/packages/client/src/pages/leaderboard/typings.ts
@@ -7,7 +7,7 @@ export type TLeaderBoard = {
   id: number;
   name: string;
   avatar?: string;
-  points: number;
+  score: number;
   place: number;
 };
 

--- a/packages/client/src/pages/leaderboard/typings.ts
+++ b/packages/client/src/pages/leaderboard/typings.ts
@@ -13,7 +13,7 @@ export type TLeaderBoard = {
 
 export type TLeaderBoardProps = {
   data: TLeaderBoard;
-  key: number;
+  key: number | string;
   iam: boolean;
 };
 

--- a/packages/client/src/typings.d.ts
+++ b/packages/client/src/typings.d.ts
@@ -1,3 +1,3 @@
 export type StringObject = {
-  [key:string]: string
+  [key: string]: string
 };

--- a/packages/client/src/utils/apiConstans.ts
+++ b/packages/client/src/utils/apiConstans.ts
@@ -1,1 +1,2 @@
 export const BASE_URL_YANDEX = 'https://ya-praktikum.tech/api/v2';
+export const LEADERBOARD = '/leaderboard';


### PR DESCRIPTION
### API лидерборда

**Две ручки:** 
- getAllLiders (получить список)
- addLider (добавить результат)
В дальнейшем можно (нужно) сделать выборку только по нашей команде, просто пока нет данных я дергаю всех игроков

Проверила работу обеих ручек, добавление пользователя на примере:

**UPD:** убрала передачу place в addLider, т.к. мы не можем знать, какое у игрока место. 
В компоненте таблицы уже раздадим place игрокам, если он не придет с бэкенда

![184732](https://user-images.githubusercontent.com/92124822/221421008-bfed6efc-b48f-4bd5-b824-4a63f5a869f0.jpg)
![002631](https://user-images.githubusercontent.com/92124822/221303131-8953d57a-39eb-4cc8-9a5f-82f98f01f13c.jpg)


### Компонент Loader 
Просто крутилка, пока что использую только при загрузке данных в таблице лидерборда

![001732](https://user-images.githubusercontent.com/92124822/221302470-e47bf053-364f-4e49-baea-e6c04b6d968e.jpg)
