### PR TITLE
feat(task-65): send points to LB API, create unique LB, game-end page

### DIFF
--- a/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
+++ b/packages/client/src/api/LeaderboardAPI/LeaderboardAPI.ts
@@ -1,4 +1,4 @@
-import { BASE_URL_YANDEX, LEADERBOARD } from '../../utils/apiConstans';
+import { BASE_URL_YANDEX, LEADERBOARD, TEAM_NAME } from '../../utils/apiConstans';
 import { TLeaderboard, TLider } from './typings';
 
 class LeaderboardAPI {
@@ -6,6 +6,24 @@ class LeaderboardAPI {
 
   async getAllLiders(data: TLeaderboard) {
     const response: Response = await fetch(`${this._baseUrl}/all`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (response.ok) {
+      const result = await response.json();
+      return result;
+    }
+
+    return Promise.reject(response.status);
+  }
+
+  async getTeamLiders(data: TLeaderboard) {
+    const response: Response = await fetch(`${this._baseUrl}/${TEAM_NAME}`, {
       method: 'POST',
       credentials: 'include',
       headers: {

--- a/packages/client/src/api/LeaderboardAPI/typings.ts
+++ b/packages/client/src/api/LeaderboardAPI/typings.ts
@@ -3,6 +3,7 @@ export type TLider = {
     id: number;
     name: string;
     score: number;
+    level?: number;
     avatar?: string;
   };
   ratingFieldName: string;

--- a/packages/client/src/components/GameScreens/EndScreen/EndScreen.module.css
+++ b/packages/client/src/components/GameScreens/EndScreen/EndScreen.module.css
@@ -4,10 +4,21 @@
 
 .text {
   margin-top: auto;
-  margin-bottom: auto;
+  margin-bottom: 0;
   font-size: 4em;
   font-weight: 700;
   color: var(--game-descr-font-color);
+  line-height: 1;
+}
+
+.score {
+  font-size: 3em;
+  color: var(--accent-color);
+}
+
+.tries {
+  font-size: 1.5em;
+  color: var(--accent-color);
 }
 
 .video {

--- a/packages/client/src/components/GameScreens/EndScreen/EndScreen.tsx
+++ b/packages/client/src/components/GameScreens/EndScreen/EndScreen.tsx
@@ -1,9 +1,14 @@
 import classNames from 'classnames';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '../../Button';
 import { GameStatus } from '../../../pages/GamePage/typings';
 import commonStyles from '../GameScreens.module.css';
 import styles from './EndScreen.module.css';
 import type { Props } from './typings';
+import { Paths } from '../../../utils/routeConstants';
+import { useAppSelector } from '../../../store/hooks';
+import { selectGameData } from '../../../store/selectors';
+import { TGameState } from '../../../store/typings';
 
 const titleMap = new Map<GameStatus, string>([
   [GameStatus.WIN, 'FLAWLESS VICTORY'],
@@ -16,17 +21,34 @@ const videoMap = new Map<GameStatus, string>([
 ]);
 
 export function EndScreen({ status, onClickPrimaryBtn }: Props) {
+  const navigate = useNavigate();
   const endScreenClassName = classNames(commonStyles.dummyScreen, styles.container);
+  const gameData: TGameState = useAppSelector(selectGameData);
+  const { score, tryCount } = gameData;
 
   return (
     <div className={endScreenClassName}>
       <span className={styles.text}>{titleMap.get(status)}</span>
+      <span className={styles.score}>
+        {'Очки: '}
+        { score }
+      </span>
+      <span className={styles.tries}>
+        {'Попытки: '}
+        { tryCount }
+      </span>
       <video className={styles.video} autoPlay loop muted src={videoMap.get(status)} />
       <Button
         extraClassName={commonStyles.button}
         onClick={onClickPrimaryBtn}
       >
         Начать заново
+      </Button>
+      <Button
+        extraClassName={commonStyles.buttonLight}
+        onClick={() => navigate(Paths.LEADERBOARD)}
+      >
+        Таблица лидеров
       </Button>
     </div>
   );

--- a/packages/client/src/components/GameScreens/GameScreens.module.css
+++ b/packages/client/src/components/GameScreens/GameScreens.module.css
@@ -3,7 +3,7 @@
   top: 0;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 20px;
   align-items: center;
   width: 100%;
   height: 100%;
@@ -15,6 +15,13 @@
 .button {
   max-width: 400px;
   color: var(--game-descr-font-color);
+}
+
+.buttonLight {
+  max-width: 400px;
+  color: var(--game-descr-font-color);
+  background-color: var(--btn-secondary-color);
+  border: 1px solid;
 }
 
 

--- a/packages/client/src/hooks/useLeaders.ts
+++ b/packages/client/src/hooks/useLeaders.ts
@@ -7,7 +7,7 @@ export function useLeaders(callback: (a: TLeaderBoard[]) => void): [() => void, 
   const [error, setError] = useState('');
 
   const fetchLeaders = () => {
-    leaderboardAPI.getAllLiders({
+    leaderboardAPI.getTeamLiders({
       ratingFieldName: 'score',
       cursor: 0,
       limit: 15,

--- a/packages/client/src/pages/GamePage/GamePage.tsx
+++ b/packages/client/src/pages/GamePage/GamePage.tsx
@@ -8,10 +8,18 @@ import { Button } from '../../components/Button';
 import { toggleFullScreen } from './utils/toggleFullScreen';
 import { IconFullscreen } from '../../components/Icons/IconFullscreen';
 import { IconFullscreenExit } from '../../components/Icons/IconFullscreenExit';
+import { leaderboardAPI } from '../../api/LeaderboardAPI/LeaderboardAPI';
+import { TEAM_NAME } from '../../utils/apiConstans';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import { selectUserData } from '../../store/selectors';
+import { UserData } from '../../store/typings';
+import { increaseCount, setScore } from '../../store/features/gameSlice';
 
 export function GamePage() {
   const gameRef = useRef<GameCore | null>(null);
   const [gameStatus, setGameStatus] = useState<GameStatus>(GameStatus.ONBOARDING);
+  const userData: UserData | null = useAppSelector(selectUserData);
+  const dispatch = useAppDispatch();
 
   const handleClickStart = () => {
     setGameStatus(GameStatus.PREPARING);
@@ -34,7 +42,27 @@ export function GamePage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   const sentResults = () => {
-    console.log('Здесь должна быть отправка результата в API Leaderboard');
+    if (gameRef.current) {
+      const score: number = gameRef.current.getScore();
+
+      if (userData) {
+        const userId: number = userData.id;
+        const userName: string = userData.login;
+
+        dispatch(setScore(score));
+        dispatch(increaseCount());
+
+        leaderboardAPI.addLider({
+          data: {
+            id: userId,
+            name: userName,
+            score,
+          },
+          ratingFieldName: 'score',
+          teamName: TEAM_NAME,
+        });
+      }
+    }
   };
 
   const [isRunStartAnimation, setIsRunStartAnimation] = useState<boolean>(false);

--- a/packages/client/src/pages/GamePage/GamePage.tsx
+++ b/packages/client/src/pages/GamePage/GamePage.tsx
@@ -13,7 +13,7 @@ import { TEAM_NAME } from '../../utils/apiConstans';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { selectUserData } from '../../store/selectors';
 import { UserData } from '../../store/typings';
-import { increaseCount, setScore } from '../../store/features/gameSlice';
+import { increaseTryCount, setScore } from '../../store/features/gameSlice';
 
 export function GamePage() {
   const gameRef = useRef<GameCore | null>(null);
@@ -50,7 +50,7 @@ export function GamePage() {
         const userName: string = userData.login;
 
         dispatch(setScore(score));
-        dispatch(increaseCount());
+        dispatch(increaseTryCount());
 
         leaderboardAPI.addLider({
           data: {

--- a/packages/client/src/pages/GamePage/artifacts/GameCore.ts
+++ b/packages/client/src/pages/GamePage/artifacts/GameCore.ts
@@ -137,6 +137,8 @@ export class GameCore {
     this.ctx.fillText(text, x, y);
   }
 
+  public getScore = () => this._score;
+
   public setInitialState = () => {
     const {
       canvas,

--- a/packages/client/src/pages/Leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.tsx
@@ -5,10 +5,18 @@ import { Loader } from '../../components/Loader';
 import { useLeaders } from '../../hooks/useLeaders';
 import styles from './Leaderboard.module.css';
 import { Order, TLeaderBoard } from './typings';
+import { UserData } from '../../store/typings';
+import { selectUserData } from '../../store/selectors';
+import { useAppSelector } from '../../store/hooks';
 
 export function Leaderboard() {
   const [leaders, setLeaders] = useState<TLeaderBoard[]>([]);
   const [fetchLeaders, isLoading, leadersError] = useLeaders(setLeaders);
+  const userData: UserData | null = useAppSelector(selectUserData);
+  let currentPlayerId: number;
+  if (userData) {
+    currentPlayerId = userData.id;
+  }
 
   useEffect(() => {
     fetchLeaders();
@@ -28,12 +36,6 @@ export function Leaderboard() {
     }
   };
 
-  /**
-   * id текущего игрока - пока захардкодено
-   * TODO: вытащить id текущего пользователя
-   */
-  const currentPlayerId = 3;
-
   return (
     <main className={styles.leaderboard}>
       <section className={styles.wrapper}>
@@ -47,11 +49,11 @@ export function Leaderboard() {
               <tbody>
 
                 {leaders.length !== 0
-                  ? leaders.map((leader, index) => (
+                  ? leaders.map((leader) => (
                     <TableRow row={{
                       data: leader,
                       key: leader.id + leader.name,
-                      iam: (index === currentPlayerId),
+                      iam: (leader.id === currentPlayerId),
                     }}
                     />
                   ))

--- a/packages/client/src/pages/Leaderboard/Leaderboard.tsx
+++ b/packages/client/src/pages/Leaderboard/Leaderboard.tsx
@@ -13,10 +13,7 @@ export function Leaderboard() {
   const [leaders, setLeaders] = useState<TLeaderBoard[]>([]);
   const [fetchLeaders, isLoading, leadersError] = useLeaders(setLeaders);
   const userData: UserData | null = useAppSelector(selectUserData);
-  let currentPlayerId: number;
-  if (userData) {
-    currentPlayerId = userData.id;
-  }
+  const currentPlayerId = userData?.id;
 
   useEffect(() => {
     fetchLeaders();

--- a/packages/client/src/store/features/gameSlice.ts
+++ b/packages/client/src/store/features/gameSlice.ts
@@ -13,11 +13,11 @@ const gameSlice = createSlice({
     setScore(state, action) {
       state.score = action.payload;
     },
-    increaseCount(state) {
+    increaseTryCount(state) {
       state.tryCount += 1;
     },
   },
 });
 
-export const { setScore, increaseCount } = gameSlice.actions;
+export const { setScore, increaseTryCount } = gameSlice.actions;
 export const gameReducer = gameSlice.reducer;

--- a/packages/client/src/store/features/gameSlice.ts
+++ b/packages/client/src/store/features/gameSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { TGameState } from '../typings';
+
+const gameState: TGameState = {
+  score: 0,
+  tryCount: 0,
+};
+
+const gameSlice = createSlice({
+  name: 'game',
+  initialState: gameState,
+  reducers: {
+    setScore(state, action) {
+      state.score = action.payload;
+    },
+    increaseCount(state) {
+      state.tryCount += 1;
+    },
+  },
+});
+
+export const { setScore, increaseCount } = gameSlice.actions;
+export const gameReducer = gameSlice.reducer;

--- a/packages/client/src/store/selectors.ts
+++ b/packages/client/src/store/selectors.ts
@@ -7,6 +7,7 @@ export const selectAuthStatus = (state: StateObject) => state.auth.status;
 export const selectIsLogged = (state: StateObject) => state.auth.isLogged;
 export const selectAuthError = (state: StateObject) => state.auth.error;
 export const selectNavlinks = (state: StateObject) => state.auth.navLinks;
+export const selectGameData = (state: StateObject) => state.game;
 
 export const selectNavLinksByIsLogged = createSelector(
   selectNavlinks,

--- a/packages/client/src/store/store.ts
+++ b/packages/client/src/store/store.ts
@@ -1,10 +1,12 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { authReducer } from './features/authSlice';
+import { gameReducer } from './features/gameSlice';
 
 const rootReducer = combineReducers({
   // here we will be adding reducers
   // counter: counterReducer,
   auth: authReducer,
+  game: gameReducer,
 });
 
 export const setupStore = configureStore({

--- a/packages/client/src/store/typings.ts
+++ b/packages/client/src/store/typings.ts
@@ -1,14 +1,12 @@
 export type UserData = {
-  userData: {
-    id: number;
-    first_name: string;
-    second_name: string;
-    display_name: string;
-    login: string;
-    avatar: string;
-    email: string;
-    phone: string;
-  }
+  id: number;
+  first_name: string;
+  second_name: string;
+  display_name: string;
+  login: string;
+  avatar: string;
+  email: string;
+  phone: string;
 };
 
 export type StateObject = {
@@ -19,4 +17,10 @@ export type StateObject = {
     userData: UserData | null;
     navLinks: StringObject[];
   },
+  game: TGameState
+};
+
+export type TGameState = {
+  score: number;
+  tryCount: number;
 };

--- a/packages/client/src/utils/apiConstans.ts
+++ b/packages/client/src/utils/apiConstans.ts
@@ -1,2 +1,3 @@
 export const BASE_URL_YANDEX = 'https://ya-praktikum.tech/api/v2';
 export const LEADERBOARD = '/leaderboard';
+export const TEAM_NAME = 'spaceInvadersTeam';


### PR DESCRIPTION
### Доработки лидерборда, страницы окончания игры и отправка игровых очков в API лидерборда

- Сделала лидерборд уникальным для команды, отображаются только игроки, сыгравшие в нашу игру 
- Добавила отправку очков в API и сохранение данных в стор (очки и количество игр)
- Вывела очки и количество игр (попыток) на экране завершения игры, также добавила ссылку на таблицу лидеров
- Добавила выделение текущего пользователя, чтобы в таблице было видно, где ты)


**Важно:** очки перезапишутся в лидеброрде только если вы набрали больше, чем ранее.
**Если вы сыграли, но так и не появились в таблице:** зарегайте нового пользователя и попробуйте снова. У меня была такая проблема скорее всего из-за того, что я уже играла в чью-то игру и апи Яндекса меня упорно не хотел добавлять в командный лидерборд (facepalm)

![231310](https://user-images.githubusercontent.com/92124822/224510249-c439ac68-7790-49b9-aff7-04db4c1df28a.jpg)

![231845](https://user-images.githubusercontent.com/92124822/224510253-933d47ee-ed3d-46fe-9ac4-708ed63be635.jpg)
